### PR TITLE
feat: Add copy and download buttons on device with no touch and hover

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "3.1.6",
+      "version": "3.1.7",
       "dependencies": {
         "pinia": "^2.3.0",
         "socket.io-client": "^4.8.1",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/client/src/components/ReceiveItem.vue
+++ b/client/src/components/ReceiveItem.vue
@@ -263,6 +263,8 @@ function decideFileType(): string {
 
   return 'mdi-file-document'
 }
+
+const supportsHover = window.matchMedia('(hover: hover)').matches
 </script>
 
 <template>
@@ -288,9 +290,15 @@ function decideFileType(): string {
         :src="props.url"
         alt="Photo"
       />
-      <div class="copy-cover blur">
-        <span class="mdi mdi-download"></span>
-      </div>
+    </div>
+    <div
+      v-if="props.success"
+      :class="{
+        'copy-cover blur': supportsHover,
+        'none-hover': !supportsHover,
+      }"
+    >
+      <span class="mdi mdi-download"></span>
     </div>
   </a>
   <div
@@ -305,10 +313,16 @@ function decideFileType(): string {
     <span class="mdi mdi-message-text"></span>
     <div class="download-item-detail">
       <p class="download-item-content">{{ props.name }}</p>
-      <div class="copy-cover blur">
-        <span class="mdi mdi-check-bold" v-if="copied"></span>
-        <span class="mdi mdi-content-copy" v-else></span>
-      </div>
+    </div>
+    <div
+      v-if="props.success"
+      :class="{
+        'copy-cover blur': supportsHover,
+        'none-hover': !supportsHover,
+      }"
+    >
+      <span class="mdi mdi-check-bold" v-if="copied"></span>
+      <span class="mdi mdi-content-copy" v-else></span>
     </div>
   </div>
   <a
@@ -327,9 +341,15 @@ function decideFileType(): string {
     <span class="mdi mdi-link-variant"></span>
     <div class="download-item-detail">
       <p class="download-item-content">{{ props.name }}</p>
-      <div class="copy-cover blur">
-        <span class="mdi mdi-open-in-new"></span>
-      </div>
+    </div>
+    <div
+      v-if="props.success"
+      :class="{
+        'copy-cover blur': supportsHover,
+        'none-hover': !supportsHover,
+      }"
+    >
+      <span class="mdi mdi-open-in-new"></span>
     </div>
   </a>
 </template>
@@ -507,5 +527,9 @@ function decideFileType(): string {
       height: 100%;
     }
   }
+}
+
+.none-hover {
+  align-self: flex-start;
 }
 </style>

--- a/client/src/components/SendItem.vue
+++ b/client/src/components/SendItem.vue
@@ -263,6 +263,8 @@ function decideFileType(): string {
 
   return 'mdi-file-document'
 }
+
+const supportsHover = window.matchMedia('(hover: hover)').matches
 </script>
 
 <template>
@@ -288,9 +290,15 @@ function decideFileType(): string {
         :src="props.url"
         alt="Photo"
       />
-      <div class="copy-cover blur">
-        <span class="mdi mdi-download"></span>
-      </div>
+    </div>
+    <div
+      v-if="props.success"
+      :class="{
+        'copy-cover blur': supportsHover,
+        'none-hover': !supportsHover,
+      }"
+    >
+      <span class="mdi mdi-download"></span>
     </div>
   </a>
   <div
@@ -305,10 +313,16 @@ function decideFileType(): string {
     <span class="mdi mdi-message-text"></span>
     <div class="upload-item-detail">
       <p class="upload-item-content">{{ props.name }}</p>
-      <div class="copy-cover blur">
-        <span class="mdi mdi-check-bold" v-if="copied"></span>
-        <span class="mdi mdi-content-copy" v-else></span>
-      </div>
+    </div>
+    <div
+      v-if="props.success"
+      :class="{
+        'copy-cover blur': supportsHover,
+        'none-hover': !supportsHover,
+      }"
+    >
+      <span class="mdi mdi-check-bold" v-if="copied"></span>
+      <span class="mdi mdi-content-copy" v-else></span>
     </div>
   </div>
   <a
@@ -327,9 +341,15 @@ function decideFileType(): string {
     <span class="mdi mdi-link-variant"></span>
     <div class="upload-item-detail">
       <p class="upload-item-content">{{ props.name }}</p>
-      <div class="copy-cover blur">
-        <span class="mdi mdi-open-in-new"></span>
-      </div>
+    </div>
+    <div
+      v-if="props.success"
+      :class="{
+        'copy-cover blur': supportsHover,
+        'none-hover': !supportsHover,
+      }"
+    >
+      <span class="mdi mdi-open-in-new"></span>
     </div>
   </a>
 </template>
@@ -507,5 +527,9 @@ function decideFileType(): string {
       height: 100%;
     }
   }
+}
+
+.none-hover {
+  align-self: flex-start;
 }
 </style>


### PR DESCRIPTION
fix #38 

Now on device with no touch and hover, a copy button will show beside text and a download button will show beside a file.