### PR TITLE
fix: Fixed the issue where auto download is disabled in certain browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.1.17] - 2025-03-11
+
+### Fixed
+
+- Fixed the issue where auto download is disabled in certain browsers
+
 ## [3.1.16] - 2025-02-14
 
 ### Changed

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "3.1.16",
+  "version": "3.1.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "3.1.16",
+      "version": "3.1.17",
       "dependencies": {
         "pinia": "^3.0.1",
         "socket.io-client": "^4.8.1",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "3.1.16",
+  "version": "3.1.17",
   "private": true,
   "type": "module",
   "scripts": {

--- a/client/src/components/ReceiveItem.vue
+++ b/client/src/components/ReceiveItem.vue
@@ -35,14 +35,30 @@ function onTextClick(): void {
 
 const supportsHover = window.matchMedia('(hover: hover)').matches
 
-const downloadLink = ref(null)
+const downloadLink = ref<HTMLAnchorElement | null>(null)
+
+// Auto download may be restricted in some environments, such as iOS and DuckDuckGo desktop.
+const isRestrictedEnv = () => {
+  const ua = navigator.userAgent
+  return (
+    /(iPhone|iPod|iPad).*AppleWebKit/i.test(ua) ||
+    /DuckDuckGo\/\d+\.\d+/.test(ua)
+  )
+}
 
 watch(
   () => props.success,
   success => {
-    if (success && autoDownload.value && props.type === 'TRANSFER_TYPE_FILE') {
+    if (
+      success &&
+      autoDownload.value &&
+      props.type === 'TRANSFER_TYPE_FILE' &&
+      !isRestrictedEnv()
+    ) {
       setTimeout(() => {
-        downloadLink.value.click()
+        if (downloadLink.value) {
+          downloadLink.value.click()
+        }
       }, 1000)
     }
   },


### PR DESCRIPTION
# Description

Fixed the issue where auto download is disabled in certain browsers.

It is now unable in browsers like Safari and DuckDuckGo.

Fixes #71 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
